### PR TITLE
Stringify the invoice metadata

### DIFF
--- a/pages/api/lnurlp/[username].ts
+++ b/pages/api/lnurlp/[username].ts
@@ -101,7 +101,6 @@ export default async function (req: NextApiRequest, res: NextApiResponse) {
   }
   const accountUsername = username ? username.toString() : ""
 
-  console.log(`accountUsername = ${accountUsername}`)
   const lnurl = await getLnurl(accountUsername, req)
   if (!lnurl) {
     return res.json({
@@ -121,7 +120,7 @@ export default async function (req: NextApiRequest, res: NextApiResponse) {
     callback: details.callback,
     maxSendable: details.max,
     minSendable: details.min,
-    metadata: details.metadata,
+    metadata: JSON.stringify(details.metadata),
     tag: "payRequest",
     domain: details.domain,
     description: details.description,


### PR DESCRIPTION
This change fixes the UI metadata validation error described here: https://github.com/lnflash/flash-mobile/issues/133

The issue was caused by the flash-pay server parsing the `invoice-requirements` before propogating to the UI. In doing so, the format was changed from a string to JSON, which caused a discrepancy from what the UI was in the invoice from Ibex. Converting the JSON back to a string when serializes satisfies this UI condition.

This change has been deployed and tested in the staging environment